### PR TITLE
Rollback fixes

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -124,7 +124,7 @@ pub struct LooseChainHeightEntry {
 }
 impl LooseChainHeightEntry {
     pub fn header_hash(&self) -> HeaderHash {
-        HeaderHash::new(&self.hash)
+        HeaderHash::from(self.hash.clone())
     }
 }
 


### PR DESCRIPTION
During testing of rollback feature, two issues were found that resulted in manlfunctions or panics:

# HeaderHash vs BlockHash misconversion

HeaderHash and BlockHash are the same hash but just Blake2b256 vs raw byte slice of the same hash.
This caused header_hash() to re-hash the hash, giving incorrect hashes
and thus breaking the rollback code that it was written for.

This change was tested with the new rollback code and with a test
assert.

# Asserts not taking into account boundary blocks not increasing difficulty

Epoch boundary blocks don't contribute to the difficulty of the chain,
but some asserts in Storage written for the rollback feature did not
take this into account, which caused panics during rollback.

These changes were tested under rollback (and existing unit tests).