### PR TITLE
More rollback fixes

### DIFF
--- a/storage/src/epoch.rs
+++ b/storage/src/epoch.rs
@@ -148,7 +148,7 @@ pub fn epoch_read_pack(config: &StorageConfig, epochid: EpochId) -> Result<PackH
 pub fn epoch_read_chainstate_ref(config: &StorageConfig, epochid: EpochId) -> Result<HeaderHash> {
     let mut sz = [0u8; hash::HASH_SIZE];
     read_bytes_at_offset(config, epochid, EPOCH_CHAINSTATE_REF_OFFSET, &mut sz)?;
-    Ok(HeaderHash::new(&sz))
+    Ok(HeaderHash::from(sz))
 }
 
 pub fn epoch_read_size(config: &StorageConfig, epochid: EpochId) -> Result<serialize::Size> {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -461,7 +461,7 @@ impl Storage {
         if !dir.exists() {
             return Err(Error::EpochNotFound(epoch_id));
         }
-        fs::remove_dir(dir)?;
+        fs::remove_dir_all(dir)?;
         self.chain_height_idx.packed_idx.pop();
         Ok(())
     }


### PR DESCRIPTION
These two fixes combined resolve an issue caused by rolling back via multiple resyncs past epoch boundary after fork.