### PR TITLE
Option #1: Rollback delete loose only

### DIFF
--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -386,7 +386,7 @@ fn perform_rollback(
                 // We drop either whole index, or just stability tail
                 let drop = min(len, net_cfg.epoch_stability_depth);
                 storage
-                    .loose_index_drop_from_head(drop)
+                    .loose_index_drop_from_head(drop, true)
                     .expect("Failed to drop loose index head!");
                 // Find new tip after rollback
                 let tip = if len > drop {

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -401,31 +401,7 @@ fn perform_rollback(
             Err(e) => panic!("Can't lock storage! {:?}", e),
         }
     } else {
-        // Either we are syncing historical data and rollback is in old epoch
-        // Or we dropped all loose blocks and now latest tip is in packed epoch
-        let current_epoch = last_date.get_epochid();
-        match storage.write() {
-            Ok(mut storage) => {
-                let last_packed_epoch = (storage.packed_epochs_len() - 1) as u64;
-                if current_epoch == last_packed_epoch {
-                    // We are inside last packed epoch
-                    // Drop current epoch and roll back to previous one
-                    storage.drop_packed_epoch(current_epoch)?;
-                } else {
-                    panic!(
-                        "Rollback while in a stable epoch, but current epoch does not match last packed epoch! (current_epoch={}, last_packed_epoch={})",
-                        current_epoch,
-                        last_packed_epoch,
-                    );
-                }
-            }
-            Err(e) => panic!("Can't lock storage! {:?}", e),
-        }
-        return Ok(restore_previous_tip_for_epoch(
-            current_epoch,
-            net_cfg,
-            storage_config,
-        ));
+        panic!("Syncing historical data and rollback is in old epoch, or dropped all loose blocks and latest tip in packed epoch.");
     }
 }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -442,7 +442,11 @@ impl Storage {
         self.chain_height_idx.packed_idx.len()
     }
 
-    pub fn loose_index_drop_from_head(&mut self, len: usize, delete_dropped_blobs: bool) -> Result<()> {
+    pub fn loose_index_drop_from_head(
+        &mut self,
+        len: usize,
+        delete_dropped_blobs: bool,
+    ) -> Result<()> {
         let read_idx = self.chain_height_idx.loose_idx.clone();
         let size = read_idx.len();
         if size < len {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -442,13 +442,18 @@ impl Storage {
         self.chain_height_idx.packed_idx.len()
     }
 
-    pub fn loose_index_drop_from_head(&mut self, len: usize) -> Result<()> {
+    pub fn loose_index_drop_from_head(&mut self, len: usize, delete_dropped_blobs: bool) -> Result<()> {
         let read_idx = self.chain_height_idx.loose_idx.clone();
         let size = read_idx.len();
         if size < len {
             return Err(Error::StorageError(StorageError::IndexQueryOutOfBound(
                 len, size,
             )));
+        }
+        if delete_dropped_blobs {
+            for entry in read_idx[0..len].to_vec() {
+                blob::remove(&self, &entry.hash);
+            }
         }
         self.chain_height_idx.loose_idx = read_idx[len..].to_vec();
         Ok(())


### PR DESCRIPTION
This option will simply disallow any rollbacks into packed epochs to avoid having to deal with cleaning up local files and lookups relating to the dropped packed epochs. It will still remove all loose (blob) blocks that were reverted as part of a rollback.