### PR TITLE
Option #2: Rollback delete packed too

### DIFF
--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -386,7 +386,7 @@ fn perform_rollback(
                 // We drop either whole index, or just stability tail
                 let drop = min(len, net_cfg.epoch_stability_depth);
                 storage
-                    .loose_index_drop_from_head(drop)
+                    .loose_index_drop_from_head(drop, true)
                     .expect("Failed to drop loose index head!");
                 // Find new tip after rollback
                 let tip = if len > drop {

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -415,7 +415,10 @@ fn perform_rollback(
                     // Drop current epoch and roll back to previous one
                     // Note: last_block must be the last block in an epoch in order for it to find the correct
                     //       chain_state hash to delete.
-                    assert_eq!(last_date.slotid(), Some((net_cfg.epoch_stability_depth * 10 - 1) as u16));
+                    assert_eq!(
+                        last_date.slotid(),
+                        Some((net_cfg.epoch_stability_depth * 10 - 1) as u16)
+                    );
                     storage.drop_packed_epoch(current_epoch, last_block)?;
                 } else {
                     panic!(

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -442,7 +442,11 @@ impl Storage {
         self.chain_height_idx.packed_idx.len()
     }
 
-    pub fn loose_index_drop_from_head(&mut self, len: usize, delete_dropped_blobs: bool) -> Result<()> {
+    pub fn loose_index_drop_from_head(
+        &mut self,
+        len: usize,
+        delete_dropped_blobs: bool,
+    ) -> Result<()> {
         let read_idx = self.chain_height_idx.loose_idx.clone();
         let size = read_idx.len();
         if size < len {
@@ -478,7 +482,10 @@ impl Storage {
         self.lookups.remove(&pack_hash);
         fs::remove_file(self.config.get_pack_filepath(&pack_hash))?;
         fs::remove_file(self.config.get_index_filepath(&pack_hash))?;
-        fs::remove_file(self.config.get_chain_state_filepath(last_block.as_hash_bytes()))?;
+        fs::remove_file(
+            self.config
+                .get_chain_state_filepath(last_block.as_hash_bytes()),
+        )?;
         Ok(())
     }
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -442,13 +442,18 @@ impl Storage {
         self.chain_height_idx.packed_idx.len()
     }
 
-    pub fn loose_index_drop_from_head(&mut self, len: usize) -> Result<()> {
+    pub fn loose_index_drop_from_head(&mut self, len: usize, delete_dropped_blobs: bool) -> Result<()> {
         let read_idx = self.chain_height_idx.loose_idx.clone();
         let size = read_idx.len();
         if size < len {
             return Err(Error::StorageError(StorageError::IndexQueryOutOfBound(
                 len, size,
             )));
+        }
+        if delete_dropped_blobs {
+            for entry in read_idx[0..len].to_vec() {
+                blob::remove(&self, &entry.hash);
+            }
         }
         self.chain_height_idx.loose_idx = read_idx[len..].to_vec();
         Ok(())


### PR DESCRIPTION
Another option for handling deep rollbacks into a previously packed epoch. It clears all local packed files. The previous (current) codebase only clears 1 of the several categories, and does not remove the lookups from Storage. In this option, both packed and loose blocks that are dropped as part of a rollback are entirely cleared.