### PR TITLE
Added tests for rollback functionality.

### DIFF
--- a/exe-common/src/lib.rs
+++ b/exe-common/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate cardano;
 extern crate cardano_storage;
+#[macro_use]
 extern crate cbor_event;
 extern crate protocol;
 extern crate rand;


### PR DESCRIPTION
To test for rollbacks, we generate some minimal blockchain history with
a mocked out API to sync to for getting blocks to most accurately
simulate an actual sync/rollback. After this we generate an alternate
history and test that the next sync properly rolls back the changes.

These tests are quite computationally expensive due to the fact
that constants 2160/21600 (stability depth/slots per epoch) are
hard-coded in rust/cardano a lot, we have to generate epochs this big.

Also, lots of assumptions in rust-cardano about the epoch you are
syncing to causes syncs to a chain within the first epoch to crash
exacerbate this.

Due to this the test are marked as #[ignore] so they are not triggered
by a quick `cargo test` call. To call them, run `cargo test -- --ignored`,
optionally specifying one or more by name.

This is a rebased and updated version of #9 that is adjusted for the changes of #13 