### PR TITLE
Sync ntt error

### DIFF
--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -15,7 +15,7 @@ use network::{
     Error::ProtocolError,
     Peer, Result,
 };
-use protocol::Error::{NttError, ServerError};
+use protocol::Error::ServerError;
 use std::cmp::min;
 use std::mem;
 use std::sync::{Arc, RwLock};
@@ -40,7 +40,7 @@ fn net_sync_to<A: Api>(
     storage: Arc<RwLock<Storage>>,
     tip_header: &BlockHeader,
 ) -> Result<()> {
-    info!("YOU ARE SYNCING TO THE SYNC-NTT-ERROR BRANCH");
+    info!("YOU ARE SYNCING TO THE SYNC-NTT-ERROR BRANCH #2");
     let tip = BlockRef {
         hash: tip_header.compute_hash(),
         parent: tip_header.get_previous_header(),
@@ -457,52 +457,7 @@ pub fn net_sync<A: Api>(
             .expect("Failed to write net-tip into storage!")
             .net_tip = Some(tip_header.clone());
 
-        let max_sync_attempts = 3;
-        let mut sync_attemps = 1;
-        let mut latest_tip = match storage.read().unwrap().get_block_from_tag(&tag::HEAD) {
-            Ok(block) => Some(block.header().compute_hash()),
-            Err(_) => None,
-        };
-        loop {
-            // Some networking errors can occur occasionally - in these cases, simply retry
-            match net_sync_to(net, net_cfg, genesis_data, storage.clone(), &tip_header) {
-                Ok(()) => {
-                    break;
-                }
-                Err(e) => {
-                    if let ProtocolError(NttError(e)) = &e {
-                        if format!("{:?}", &e).contains("failed to fill whole buffer") {
-                            let new_latest_tip =
-                                match storage.read().unwrap().get_block_from_tag(&tag::HEAD) {
-                                    Ok(block) => Some(block.header().compute_hash()),
-                                    Err(_) => None,
-                                };
-                            // TODO: remove after network error during sync testing
-                            info!("latest_tip     = {:?}", latest_tip);
-                            info!("new_latest_tip = {:?}", new_latest_tip);
-                            if new_latest_tip != latest_tip {
-                                latest_tip = new_latest_tip;
-                                sync_attemps = 1;
-                            }
-                            if sync_attemps < max_sync_attempts {
-                                warn!(
-                                    "networking error in net.get_blocks() - attempt {} / {}",
-                                    sync_attemps, max_sync_attempts
-                                );
-                                std::thread::sleep(Duration::from_secs(10));
-                                continue;
-                            } else {
-                                panic!(
-                                    "max sync attempts ({}) reached for epoch",
-                                    max_sync_attempts
-                                );
-                            }
-                        }
-                    }
-                    panic!("`net_sync_to` error: {:?}", e);
-                }
-            }
-        }
+        net_sync_to(net, net_cfg, genesis_data, storage.clone(), &tip_header)?;
 
         if sync_once {
             break;

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -40,7 +40,6 @@ fn net_sync_to<A: Api>(
     storage: Arc<RwLock<Storage>>,
     tip_header: &BlockHeader,
 ) -> Result<()> {
-    info!("YOU ARE SYNCING TO THE SYNC-NTT-ERROR BRANCH #2");
     let tip = BlockRef {
         hash: tip_header.compute_hash(),
         parent: tip_header.get_previous_header(),
@@ -276,8 +275,6 @@ fn net_sync_to<A: Api>(
                             &tag::HEAD,
                             &chain_state_before.last_block.as_ref(),
                         );
-                        // TODO: remove after network error during sync testing
-                        info!("HEAD now: {}", chain_state_before.last_block);
                     }
                 }
                 is_epoch_with_ebb = date.is_boundary()
@@ -348,8 +345,6 @@ fn net_sync_to<A: Api>(
         &tag::HEAD,
         chain_state.last_block.as_ref(),
     );
-    // TODO: remove after network error during sync testing
-    info!("HEAD now: {}", chain_state.last_block);
 
     Ok(())
 }

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -40,6 +40,7 @@ fn net_sync_to<A: Api>(
     storage: Arc<RwLock<Storage>>,
     tip_header: &BlockHeader,
 ) -> Result<()> {
+    info!("YOU ARE SYNCING TO THE SYNC-NTT-ERROR BRANCH");
     let tip = BlockRef {
         hash: tip_header.compute_hash(),
         parent: tip_header.get_previous_header(),

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -211,9 +211,7 @@ impl Storage {
                 let new_tip_diff = u64::from(entry.difficulty);
                 if let Some(prev_tip_diff) = prev_diff {
                     // Here we are going bavkward in history, so check next height is lower
-                    assert!(
-                        (new_tip_diff < prev_tip_diff) && (prev_tip_diff - new_tip_diff == 1)
-                    );
+                    assert!((new_tip_diff < prev_tip_diff) && (prev_tip_diff - new_tip_diff == 1));
                 }
                 if !header.is_boundary_block() {
                     // Only update prev diff is currently checked block is not an EBB

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -209,17 +209,17 @@ impl Storage {
                 let header = block.header();
                 let entry = Storage::create_loose_index_entry(&header);
                 let new_tip_diff = u64::from(entry.difficulty);
-                // FIXME: add in a new_tip_diff == prev_tip_diff assert for the boundary block case
-                // and verify that this is indeed the proper action and does not panic existing flows.
-                if !header.is_boundary_block() {
-                    if let Some(prev_tip_diff) = prev_diff {
-                        // Here we are going bavkward in history, so check next height is lower
-                        assert!(
-                            (new_tip_diff < prev_tip_diff) && (prev_tip_diff - new_tip_diff == 1)
-                        );
-                    }
+                if let Some(prev_tip_diff) = prev_diff {
+                    // Here we are going bavkward in history, so check next height is lower
+                    assert!(
+                        (new_tip_diff < prev_tip_diff) && (prev_tip_diff - new_tip_diff == 1)
+                    );
                 }
-                prev_diff = Some(new_tip_diff);
+                if !header.is_boundary_block() {
+                    // Only update prev diff is currently checked block is not an EBB
+                    // Cuz EBBs don't increment the chain difficulty
+                    prev_diff = Some(new_tip_diff);
+                }
                 // Here we append elements to the end,
                 // because we are iterating from newer block to older
                 self.chain_height_idx.loose_idx.push(entry);


### PR DESCRIPTION
Propagate errors during syncing instead of simply panicing so that we can handle them in other programs that use it, ie cardano-http-bridge.

The purpose of this was to handle an issue where haskell nodes sometimes failed with a certain networking error which would simply cause panics, but reconnecting and restarting the sync would get around this. A related PR in the bridge will make use of this and retry up to a point upon this failure.