### PR TITLE
Removed chain-state cloning

### DIFF
--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -5,7 +5,6 @@ use fee::FeeAlgorithm;
 use tx::{TxAux, TxInWitness, TxoPointer};
 
 impl ChainState {
-
     /// Verify a block in the context of the chain. Regardless of
     /// errors, the chain state is updated to reflect the changes
     /// introduced by this block.

--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -14,7 +14,7 @@ impl ChainState {
         self.append_block(block_hash, blk)
     }
 
-    pub fn validate_block(&mut self, block_hash: &HeaderHash, blk: &Block) -> Result<(), Error> {
+    pub fn validate_block(&self, block_hash: &HeaderHash, blk: &Block) -> Result<(), Error> {
         self.do_verify(block_hash, blk)
     }
 

--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -5,14 +5,22 @@ use fee::FeeAlgorithm;
 use tx::{TxAux, TxInWitness, TxoPointer};
 
 impl ChainState {
+
     /// Verify a block in the context of the chain. Regardless of
     /// errors, the chain state is updated to reflect the changes
     /// introduced by this block.
     /// FIXME: we may want to return all errors rather than just the first.
     pub fn verify_block(&mut self, block_hash: &HeaderHash, blk: &Block) -> Result<(), Error> {
-        let mut res = Ok(());
+        self.validate_block(block_hash, blk)?;
+        self.append_block(block_hash, blk)
+    }
 
-        add_error(&mut res, self.do_verify(block_hash, blk));
+    pub fn validate_block(&mut self, block_hash: &HeaderHash, blk: &Block) -> Result<(), Error> {
+        self.do_verify(block_hash, blk)
+    }
+
+    pub fn append_block(&mut self, block_hash: &HeaderHash, blk: &Block) -> Result<(), Error> {
+        let mut res = Ok(());
 
         match blk {
             Block::BoundaryBlock(blk) => {


### PR DESCRIPTION
Removed need to clone chain-state, but it required to split the "verify_block" operation into two separate steps: validating a block and then actually appending the block to the chain_state.

The need for the change comes from the fact that previously no detected errors affected anything (there were no rollback processing), but now we need to first validate a block for rollbacks, then close the previous epoch with old chain_state, if the block is good, and only then change the chain_state by processing the pre-validated block.