### PR TITLE
Fix block by height search in loose index

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -431,7 +431,7 @@ impl Storage {
                 debug!("Search by height in loose index found EBB. Proceeding with caution.");
                 if (loose_index_len - idx) > 1 {
                     let idx2 = idx+1;
-                    let entry2 = &self.chain_height_idx.loose_idx[idx+1];
+                    let entry2 = &self.chain_height_idx.loose_idx[idx2];
                     let error_msg: Option<&str> =
                         if u64::from(entry2.difficulty) != find_diff {
                             Some("the height does not match")

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -446,14 +446,13 @@ impl Storage {
                 let idx2 = idx + 1;
                 let entry2 = &self.chain_height_idx.loose_idx[idx2];
                 // Validating next found entry
-                let error_msg: Option<&str> =
-                    if u64::from(entry2.difficulty) != find_diff {
-                        Some("the height does not match")
-                    } else if entry2.date.is_boundary() {
-                        Some("it's also an EBB")
-                    } else {
-                        None
-                    };
+                let error_msg: Option<&str> = if u64::from(entry2.difficulty) != find_diff {
+                    Some("the height does not match")
+                } else if entry2.date.is_boundary() {
+                    Some("it's also an EBB")
+                } else {
+                    None
+                };
                 if let Some(error_msg) = error_msg {
                     error!(
                         "Search by height in loose index found EBB. \
@@ -468,7 +467,7 @@ impl Storage {
                         idx2,
                         entry2,
                     );
-                    return Err(Error::BlockHeightNotFound(find_diff))
+                    return Err(Error::BlockHeightNotFound(find_diff));
                 }
                 debug!("Found valid loose alternative at index right before EBB.");
                 return Ok(Some(entry2));


### PR DESCRIPTION
1. Added check on whether the loose entry found by height is an EBB
2. Added processing for both possible cases, when found EBB is the oldest available loose block, or if there are some older loose blocks (possible when previous epoch is not stable yet)
3. Refactored the whole function for better sequential readability step-by-step

Before fix:
![image](https://user-images.githubusercontent.com/5585355/63093615-a52cdf80-bf6e-11e9-9e7c-06d0507e18de.png)

After fix:
![image](https://user-images.githubusercontent.com/5585355/63093639-b8d84600-bf6e-11e9-955e-22ab6b294802.png)
